### PR TITLE
Fix java.lang.NoClassDefFoundError: org / springframework / util / unit / DataSize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-starter-parent</artifactId>
-				<version>2.0.3.RELEASE</version>
+				<version>2.3.2.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
wrong dependency number between parent and dependency management